### PR TITLE
Fix for joins function and lists reversing

### DIFF
--- a/lib/liquid/filters.ex
+++ b/lib/liquid/filters.ex
@@ -3,6 +3,7 @@ defmodule Liquid.Filters do
   Applies a chain of filters passed from Liquid.Variable
   """
   import Kernel, except: [round: 1, abs: 1]
+  import Liquid.Utils, only: [to_number: 1]
   alias Liquid.HTML
 
   defmodule Functions do
@@ -446,10 +447,9 @@ defmodule Liquid.Filters do
 
     defp to_iterable(input) when is_list(input) do
       case List.first(input) do
-        first when is_number(first) ->
-          input |> List.flatten
         first when is_nil(first) -> []
-        _ -> [input]
+        first when is_tuple(first) -> [input]
+        _ -> input |> List.flatten
       end
     end
 
@@ -457,23 +457,6 @@ defmodule Liquid.Filters do
       # input when is_map(input) -> [input]
       # input when is_tuple(input) -> input
       List.wrap(input)
-    end
-
-    defp to_number(nil), do: 0
-
-    defp to_number(input) when is_number(input), do: input
-
-    defp to_number(input) when is_binary(input) do
-      case Integer.parse(input) do
-        {integer, ""} -> integer
-        :error -> 0
-        {integer, remainder} ->
-          case Float.parse(input) do
-            {_, float_remainder} when float_remainder == remainder ->
-              integer
-            {float, _} -> float
-          end
-      end
     end
 
     defp get_int_and_counter(input) when is_integer(input), do: {input, 0}

--- a/lib/liquid/render.ex
+++ b/lib/liquid/render.ex
@@ -8,7 +8,7 @@ defmodule Liquid.Render do
 
   def render(%Template{root: root}, %Context{}=context) do
     { output, context } = render([], root, context)
-    { :ok, output |> List.flatten |> Enum.reverse |> Enum.join, context }
+    { :ok, output |> to_text, context }
   end
 
   def render(output, [], %Context{}=context) do
@@ -28,7 +28,7 @@ defmodule Liquid.Render do
   end
 
   def render(output, %Variable{}=v, %Context{}=context) do
-    rendered = Variable.lookup(v, context)
+    rendered = Variable.lookup(v, context) |> join_list
     { [rendered|output], context }
   end
 
@@ -43,5 +43,12 @@ defmodule Liquid.Render do
       nil -> render(output, block.nodelist, context)
     end
   end
+
+  def to_text(list), do: list |> List.flatten |> Enum.reverse |> Enum.join
+
+  defp join_list(input) when is_list(input),
+   do: input |> List.flatten |> Enum.join
+
+  defp join_list(input), do: input
 
 end

--- a/lib/liquid/tags/capture.ex
+++ b/lib/liquid/tags/capture.ex
@@ -9,8 +9,8 @@ defmodule Liquid.Capture do
 
   def render(output, %Block{markup: markup, nodelist: content}, %Context{}=context) do
     variable_name = Liquid.variable_parser |> Regex.run(markup) |> hd
-    {block_output, context } = Liquid.Render.render(output, content, context)
-    result_assign = context.assigns |> Map.put(variable_name, block_output)
+    {block_output, context } = Liquid.Render.render([], content, context)
+    result_assign = context.assigns |> Map.put(variable_name, block_output |> Liquid.Render.to_text)
     context = %{context | assigns: result_assign}
     {output, context}
   end

--- a/lib/liquid/utils.ex
+++ b/lib/liquid/utils.ex
@@ -40,3 +40,29 @@ defmodule Liquid.HTML do
 
   defp escape_char(char), do: char
 end
+
+defmodule Liquid.Utils do
+  @moduledoc """
+  A number of useful utils for liquid parser/filters
+  """
+
+  @doc """
+  Converts various input to number for further processing
+  """
+  def to_number(nil), do: 0
+
+  def to_number(input) when is_number(input), do: input
+
+  def to_number(input) when is_binary(input) do
+    case Integer.parse(input) do
+      {integer, ""} -> integer
+      :error -> 0
+      {integer, remainder} ->
+        case Float.parse(input) do
+          {_, float_remainder} when float_remainder == remainder ->
+            integer
+          {float, _} -> float
+        end
+    end
+  end
+end

--- a/test/liquid/filter_test.exs
+++ b/test/liquid/filter_test.exs
@@ -150,8 +150,6 @@ defmodule Liquid.FilterTest do
     assert ["a": 1, "a": 2, "a": 3, "a": 4] == Functions.sort([{:a, 4}, {:a, 3}, {:a, 1}, {:a, 2}], "a")
   end
 
-  # FIXME: reverse ordering issue
-  @tag :skip
   test :sort_integrity do
     assert_template_result "11245", ~s({{"1: 2: 1: 4: 5" | split: ": " | sort }})
   end
@@ -368,6 +366,11 @@ defmodule Liquid.FilterTest do
 
   test :filters_nonexistent_in_chain do
     assert_template_result "Text", "{{ 'text' | upcase | nonexistent | capitalize }}"
+  end
+
+  test :filter_and_tag do
+    assert_template_result("V 1: 2: 1: 4: 5: 0 | 011245",
+                           "V {{ var2 }}{% capture var2 %}{{ '1: 2: 1: 4: 5' }}: 0{% endcapture %}{{ var2 }} | {{ var2 | split: ': ' | sort }}")
   end
 
 

--- a/test/liquid/filter_test.exs
+++ b/test/liquid/filter_test.exs
@@ -148,6 +148,11 @@ defmodule Liquid.FilterTest do
     assert [%{"a" => 1, "b" => 1}, %{"a" => 3, "b" => 2}, %{"a" => 2, "b"=> 3}] == Functions.sort([%{"a" => 3, "b" => 2}, %{"a" => 1, "b" => 1}, %{"a" => 2, "b"=> 3}], "b")
     # Elixir keyword list support
     assert ["a": 1, "a": 2, "a": 3, "a": 4] == Functions.sort([{:a, 4}, {:a, 3}, {:a, 1}, {:a, 2}], "a")
+  end
+
+  # FIXME: reverse ordering issue
+  @tag :skip
+  test :sort_integrity do
     assert_template_result "11245", ~s({{"1: 2: 1: 4: 5" | split: ": " | sort }})
   end
 

--- a/test/liquid/filter_test.exs
+++ b/test/liquid/filter_test.exs
@@ -139,6 +139,7 @@ defmodule Liquid.FilterTest do
   test :join do
     assert "1 2 3 4" == Functions.join([1, 2, 3, 4])
     assert "1 - 2 - 3 - 4" == Functions.join([1, 2, 3, 4], " - ")
+    assert_template_result "1, 1, 2, 4, 5", ~s({{"1: 2: 1: 4: 5" | split: ": " | sort | join: ", " }})
   end
 
   test :sort do
@@ -147,6 +148,7 @@ defmodule Liquid.FilterTest do
     assert [%{"a" => 1, "b" => 1}, %{"a" => 3, "b" => 2}, %{"a" => 2, "b"=> 3}] == Functions.sort([%{"a" => 3, "b" => 2}, %{"a" => 1, "b" => 1}, %{"a" => 2, "b"=> 3}], "b")
     # Elixir keyword list support
     assert ["a": 1, "a": 2, "a": 3, "a": 4] == Functions.sort([{:a, 4}, {:a, 3}, {:a, 1}, {:a, 2}], "a")
+    assert_template_result "11245", ~s({{"1: 2: 1: 4: 5" | split: ": " | sort }})
   end
 
   test :legacy_sort_hash do


### PR DESCRIPTION
Added integrity test for join along with unit tests
`to_number` function can be useful for custom users filters and now it's public