### PR TITLE
Improve minus_one custom tag example

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ defmodule ExampleTag do
     {tag, context}
   end
 
-  def render(_input, tag, context) do
+  def render(output, tag, context) do
     number = tag.markup |> Integer.parse |> elem(0)
-    {["#{number - 1}"], context}
+    {["#{number - 1}"] ++ output, context}
   end
 end
 

--- a/test/liquid/custom_tag_test.exs
+++ b/test/liquid/custom_tag_test.exs
@@ -8,9 +8,9 @@ defmodule Liquid.CustomTagTest do
       {tag, context}
     end
 
-    def render(_input, tag, context) do
+    def render(output, tag, context) do
       number = tag.markup |> Integer.parse |> elem(0)
-      {["#{number - 1}"], context}
+      {["#{number - 1}"] ++ output, context}
     end
   end
 
@@ -24,6 +24,7 @@ defmodule Liquid.CustomTagTest do
   test "custom tag from example(almost random now :)" do
     assert_template_result "123", "123{% assign qwe = 5 %}"
     assert_template_result "4", "{% minus_one 5 %}"
+    assert_template_result "a1b", "a{% minus_one 2 %}b"
   end
 
   defp assert_template_result(expected, markup, assigns \\ %{}) do


### PR DESCRIPTION
As I was writing my own custom tag I realised that the content before the custom tag was being lost.

There's nothing wrong with the code, only with the example, this PR just updates `custom_tag_test.exs` and `README.md` with a more helpful example of a custom tag.