### PR TITLE
Update slice function to allow string params for indices

### DIFF
--- a/lib/liquid/filters.ex
+++ b/lib/liquid/filters.ex
@@ -365,7 +365,9 @@ defmodule Liquid.Filters do
     end
 
     def slice(<<string::binary>>, from, to) do
-      string |> String.slice(from, to)
+      {from_int, _from_len} = from |> get_int_and_counter
+      {to_int, _to_len} = to |> get_int_and_counter
+      string |> String.slice(from_int, to_int)
     end
 
     def slice(list, 0) when is_list(list), do: list

--- a/test/liquid/filter_test.exs
+++ b/test/liquid/filter_test.exs
@@ -58,6 +58,9 @@ defmodule Liquid.FilterTest do
 
   test :slice do
     assert "oob" == Functions.slice("foobar", 1, 3)
+    assert "oob" == Functions.slice("foobar", "1", "3")
+    assert "oob" == Functions.slice("foobar", "1", 3)
+    assert "oob" == Functions.slice("foobar", 1, "3")
     assert "oobar" == Functions.slice("foobar", 1, 1000)
     assert "" == Functions.slice("foobar", 1, 0)
     assert "o" == Functions.slice("foobar", 1, 1)


### PR DESCRIPTION
Indices passed to the slice filter function from a template are sent as strings. The previous function did not convert the strings to integers, which are then passed to String.slice/3. 

Passing the indices to String.slice/3 as strings resulted in nothing being returned from the call. 