### PR TITLE
Parse date from unix time

### DIFF
--- a/lib/liquid/filters.ex
+++ b/lib/liquid/filters.ex
@@ -434,6 +434,10 @@ defmodule Liquid.Filters do
       input |> date
     end
 
+    def date(input, format) when is_integer(input) do
+      input |> Timex.from_unix() |> date(format)
+    end
+
     def date("now", format), do: Timex.now() |> date(format)
 
     def date("today", format), do: Timex.now() |> date(format)
@@ -443,8 +447,13 @@ defmodule Liquid.Filters do
         input_date |> date(format)
       else
         {:error, :invalid_format} ->
-          with {:ok, input_date} <- Timex.parse(input, "%a %b %d %T %Y", :strftime),
-               do: input_date |> date(format)
+          with {:ok, input_date} <- Timex.parse(input, "%a %b %d %T %Y", :strftime) do
+            input_date |> date(format)
+          else
+            _ ->
+              with {integer, _rem} <- Integer.parse(input),
+                do: integer |> Timex.from_unix() |> date(format)
+          end
       end
     end
 

--- a/lib/liquid/filters.ex
+++ b/lib/liquid/filters.ex
@@ -365,7 +365,9 @@ defmodule Liquid.Filters do
     end
 
     def slice(<<string::binary>>, from, to) do
-      string |> String.slice(from, to)
+      {from_int, _from_len} = from |> get_int_and_counter
+      {to_int, _to_len} = to |> get_int_and_counter
+      string |> String.slice(from_int, to_int)
     end
 
     def slice(list, 0) when is_list(list), do: list

--- a/test/liquid/filter_test.exs
+++ b/test/liquid/filter_test.exs
@@ -58,6 +58,9 @@ defmodule Liquid.FilterTest do
 
   test :slice do
     assert "oob" == Functions.slice("foobar", 1, 3)
+    assert "oob" == Functions.slice("foobar", "1", "3")
+    assert "oob" == Functions.slice("foobar", "1", 3)
+    assert "oob" == Functions.slice("foobar", 1, "3")
     assert "oobar" == Functions.slice("foobar", 1, 1000)
     assert "" == Functions.slice("foobar", 1, 0)
     assert "o" == Functions.slice("foobar", 1, 1)

--- a/test/liquid/filter_test.exs
+++ b/test/liquid/filter_test.exs
@@ -247,6 +247,11 @@ defmodule Liquid.FilterTest do
     assert "June" == Functions.date(Timex.parse!("2006-06-05 10:00:00", "%F %T", :strftime), "%B")
     assert "July" == Functions.date(~N[2006-07-05 10:00:00], "%B")
 
+    assert "July" == Functions.date(1152093600, "%B")
+    assert "July" == Functions.date("1152093600", "%B")
+    assert "2006-07-05 10:00:00" == Functions.date(1152093600, "")
+    assert "2006-07-05 10:00:00" == Functions.date("1152093600", "")
+
     assert "May" == Functions.date("2006-05-05 10:00:00", "%B")
     assert "June" == Functions.date("2006-06-05 10:00:00", "%B")
     assert "July" == Functions.date("2006-07-05 10:00:00", "%B")


### PR DESCRIPTION
Add ability for dates to be converted from unix time (seconds) using the date filter (function). 